### PR TITLE
fix(ignitor signalslistener): always listen for SIGINT

### DIFF
--- a/src/Ignitor/SignalsListener/index.ts
+++ b/src/Ignitor/SignalsListener/index.ts
@@ -9,7 +9,7 @@
 
 /**
  * Exposes the API to invoke a callback when `SIGTERM` or
- * `SIGINT (pm2 only)` signals are received.
+ * `SIGINT` signals are received.
  */
 export class SignalsListener {
   protected onCloseCallback?: () => Promise<void>
@@ -19,6 +19,7 @@ export class SignalsListener {
    */
   private kill = async function () {
     try {
+      console.log('Shutting down server...')
       await this.onCloseCallback()
       process.exit(0)
     } catch (error) {
@@ -32,10 +33,8 @@ export class SignalsListener {
    */
   public listen (callback: () => Promise<void>) {
     this.onCloseCallback = callback
-    if (process.env.pm_id) {
-      process.on('SIGINT', this.kill)
-    }
 
+    process.on('SIGINT', this.kill)
     process.on('SIGTERM', this.kill)
   }
 


### PR DESCRIPTION
## Proposed changes

This PR will make Ignitor to always listen for SIGINT so server is killable in containers.
Also ads `Shutting down server...` message when shutdown process is started

Fixes: https://github.com/AdonisCommunity/create-adonis-ts-app/issues/5

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is how killing server looks after change:
From left: 
CTRL + C while attached to container
CTRL + C while running server in bash
SIGTERM from another bash
![image](https://user-images.githubusercontent.com/6796697/76132127-ff2fe800-6019-11ea-82b9-a0a615a340d0.png)

Before change:
![image](https://user-images.githubusercontent.com/6796697/76132390-70bc6600-601b-11ea-8930-bb2bcdbabdfd.png)
Only way to kill container is open another bash instance and do `docker kill CONTAINER_ID`
