### PR TITLE
refactor: use Env variable to define the hasher and default to argon

### DIFF
--- a/templates/config/hash.txt
+++ b/templates/config/hash.txt
@@ -27,7 +27,7 @@ const hashConfig: HashConfig = {
   | free to change the default value
   |
   */
-  default: Env.get('HASH_DRIVER', 'argon') as string,
+  default: Env.get('HASH_DRIVER', 'argon') as 'argon',
 
   list: {
     /*

--- a/templates/config/hash.txt
+++ b/templates/config/hash.txt
@@ -5,6 +5,7 @@
  * file.
  */
 
+import Env from '@ioc:Adonis/Core/Env'
 import { HashConfig } from '@ioc:Adonis/Core/Hash'
 
 /*
@@ -26,7 +27,7 @@ const hashConfig: HashConfig = {
   | free to change the default value
   |
   */
-  default: 'bcrypt',
+  default: Env.get('HASH_DRIVER', 'argon') as string,
 
   list: {
     /*


### PR DESCRIPTION
Hey! 👋 

This PR swap the default hasher to `argon`.
It also use an environement variable since you may want to use another driver when testing.