### PR TITLE
Removed end tag from a link element

### DIFF
--- a/src/View/globals.js
+++ b/src/View/globals.js
@@ -41,7 +41,7 @@ module.exports = function (View, Route, Config) {
    */
   View.global('style', function (url, skipPrefix = false) {
     url = !url.endsWith('.css') && !skipPrefix ? `${url}.css` : url
-    return this.safe(`<link rel="stylesheet" href="${this.$globals.assetsUrl(url)}" />`)
+    return this.safe(`<link rel="stylesheet" href="${this.$globals.assetsUrl(url)}">`)
   })
 
   /**


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

`link` tags are Void Elements and do not need an end tag.

Source: https://html.spec.whatwg.org/multipage/syntax.html#void-elements

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
