### PR TITLE
feat(HttpExceptionHandler): add printReport method

### DIFF
--- a/adonis-typings/exception-handler.ts
+++ b/adonis-typings/exception-handler.ts
@@ -30,6 +30,7 @@ declare module '@ioc:Adonis/Core/HttpExceptionHandler' {
     protected makeJSONAPIResponse (error: any, ctx: HttpContextContract): Promise<void>
     protected makeHtmlResponse (error: any, ctx: HttpContextContract): Promise<void>
     public report (error: any, ctx: HttpContextContract): void
+    protected printReport (loggerFn: 'info' | 'warn' | 'error', error: any, ctx: HttpContextContract): void
     public handle (error: any, ctx: HttpContextContract): Promise<any>
   }
 }

--- a/src/HttpExceptionHandler/index.ts
+++ b/src/HttpExceptionHandler/index.ts
@@ -178,6 +178,13 @@ export abstract class HttpExceptionHandler {
       ? 'error'
       : (error.status >= 400) ? 'warn' : 'info'
 
+    this.printReport(loggerFn, error, ctx)
+  }
+
+  /**
+   * Print a given report
+   */
+  protected printReport (loggerFn: 'info' | 'warn' | 'error', error: any, ctx: HttpContextContract) {
     this.logger[loggerFn](this.context(ctx), error.message)
   }
 


### PR DESCRIPTION
Hey! 👋 

This PR extract the call to the logger after using the `report` method.
This will be used to allow final user to easily customize the logger format without recreating the whole `report` function.