### PR TITLE
Fix typo in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ For usage questions, please use the following resources:
 ## Sample Code (to reproduce the issue)
 <!-- YOUR ANSWER -->
 
-## Excepted outcome
+## Expected outcome
 <!-- YOUR ANSWER -->
 
 ## Actual outcome


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Fix typo in the Bug Report GitHub template.