### PR TITLE
README - Replace image content as text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-<div align="center">
-  <img src="https://res.cloudinary.com/adonisjs/image/upload/q_100/v1558612869/adonis-readme_zscycu.jpg" width="600px">
-</div>
+# AdonisJS
+A NodeJS framework highly focused on developer ergonimics, stability and confidence.
 
 <br />
 <hr>


### PR DESCRIPTION
Image content was not readable on mobile so I write the image text content and removed the image.