### PR TITLE
feat: provide subpath exports for public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
 	"name": "@adonisjs/core",
 	"version": "5.1.8",
 	"description": "Core of AdonisJS",
-	"main": "build/providers/AppProvider.js",
+	"exports": {
+		".": "./build/providers/AppProvider.js",
+		"./standalone": "./build/standalone.js",
+		"./Ignitor": "./build/src/Ignitor/index.js",
+		"./*": "./*"
+	},
 	"files": [
 		"build/adonis-typings",
 		"build/commands",


### PR DESCRIPTION
This allows to `require('@adonisjs/core/standalone')` instead of having
to deeply grab it from the build directory.
Provide a star export fallback for backwards-compatibility.
