### PR TITLE
feat: support file URL in Ignitor

### DIFF
--- a/src/Ignitor/index.ts
+++ b/src/Ignitor/index.ts
@@ -6,6 +6,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
 
 import { Application } from '@adonisjs/application'
 import { AppEnvironments } from '@ioc:Adonis/Core/Application'
@@ -18,7 +20,12 @@ import { HttpServer } from './HttpServer'
  * the application.
  */
 export class Ignitor {
-  constructor(private appRoot: string) {}
+  private appRoot: string
+
+  constructor(appRoot: string) {
+    // In ESM, ignitor is constructed with `import.meta.url`. Normalize the file URL to an absolute directory path.
+    this.appRoot = appRoot.startsWith('file:') ? dirname(fileURLToPath(appRoot)) : appRoot
+  }
 
   /**
    * Returns an instance of the application.

--- a/test/ignitor.spec.ts
+++ b/test/ignitor.spec.ts
@@ -10,6 +10,7 @@
 /// <reference path="../adonis-typings/index.ts" />
 
 import test from 'japa'
+import { pathToFileURL } from 'url'
 import { Ignitor } from '../src/Ignitor'
 import { setupApplicationFiles, fs } from '../test-helpers'
 
@@ -124,5 +125,15 @@ test.group('Ignitor | App Provider', (group) => {
     assert.deepEqual(HealthCheck.servicesList, ['env', 'appKey'])
 
     await httpServer.close()
+  })
+
+  test('construct ignitor with a file URL', async (assert) => {
+    await setupApplicationFiles()
+
+    const entryPoint = fs.basePath + '/ace.js'
+    const url = pathToFileURL(entryPoint).href
+    const httpServer = new Ignitor(url).httpServer()
+
+    assert.strictEqual(httpServer.application.appRoot, fs.basePath)
   })
 })


### PR DESCRIPTION
The URL is converted to an absolute path, so the rest works as before.
This is to enable applications written in ESM to do `new Ignitor(import.meta.url)`
as the `__dirname` variable doesn't exist in ESM.
