### PR TITLE
Edge version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "co-compose": "^4.0.0",
     "debug": "^4.1.1",
     "dotenv": "^6.2.0",
-    "edge.js": "^1.1.4",
+    "edge.js": "^2.2.0",
     "eventemitter2": "^5.0.1",
     "haye": "^2.0.2",
     "lodash": "^4.17.11",


### PR DESCRIPTION
I use adonis V4 and I got some bugs related to using Regex in View with Edge.
Until I found a possible solution at [issue](https://github.com/edge-js/edge/issues/64)

Where did you update Edge at [commit](https://github.com/edge-js/edge/commit/fe0d6830df1507dff4cf321ff1e31e945765b547)

But I noticed that the Adonis dependency was not using Edge with this fix, so I took some time to send this PR