### PR TITLE
fix: export commands with full paths

### DIFF
--- a/commands/index.ts
+++ b/commands/index.ts
@@ -8,7 +8,7 @@
  */
 
 export default [
-  '@adonisjs/core/commands/DumpRc',
-  '@adonisjs/core/commands/ListRoutes',
-  '@adonisjs/core/commands/GenerateKey',
+  '@adonisjs/core/build/commands/DumpRc.js',
+  '@adonisjs/core/build/commands/ListRoutes.js',
+  '@adonisjs/core/build/commands/GenerateKey.js',
 ]

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
 			]
 		},
 		"commands": [
-			"@adonisjs/core/commands"
+			"@adonisjs/core/build/commands/index.js"
 		],
 		"types": "@adonisjs/core",
 		"providers": [


### PR DESCRIPTION
This should be compatible with both ESM and Yarn 2 (which sadly doesn't
support the exports field).
