### PR TITLE
Cleanup code for the list routes command

### DIFF
--- a/commands/ListRoutes/TableRenderer.ts
+++ b/commands/ListRoutes/TableRenderer.ts
@@ -1,25 +1,34 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 import { BaseCommand } from '@adonisjs/ace'
-import { SerializedRouter } from './ListRoutes'
+import type { SerializedRoute } from './ListRoutes'
 
 export class RoutesTableRenderer {
-  constructor(private ui: BaseCommand['ui'], private colors: BaseCommand['colors']) {}
+  constructor(private command: BaseCommand) {}
 
   /**
    * Render the serialized routes to the console
    */
-  public render(serializedRouter: SerializedRouter) {
-    const domains = Object.keys(serializedRouter)
+  public render(serializedRoutes: Record<string, SerializedRoute[]>) {
+    const domains = Object.keys(serializedRoutes)
     const showDomainHeadline = domains.length > 1 || domains[0] !== 'root'
-    const table = this.ui.table().head(['Method', 'Route', 'Handler', 'Middleware', 'Name'])
+    const table = this.command.ui.table().head(['Method', 'Route', 'Handler', 'Middleware', 'Name'])
 
     domains.forEach((domain) => {
       if (showDomainHeadline) {
-        table.row([{ colSpan: 5, content: `Domain ${this.colors.cyan(domain)}` }])
+        table.row([{ colSpan: 5, content: `Domain ${this.command.colors.cyan(domain)}` }])
       }
 
-      serializedRouter[domain].forEach((route) => {
+      serializedRoutes[domain].forEach((route) => {
         table.row([
-          this.colors.dim(route.methods.join(', ')),
+          this.command.colors.dim(route.methods.join(', ')),
           route.pattern,
           typeof route.handler === 'function' ? 'Closure' : route.handler,
           route.middleware.join(','),

--- a/test/commands/list-routes-json.spec.ts
+++ b/test/commands/list-routes-json.spec.ts
@@ -7,8 +7,8 @@
  * file that was distributed with this source code.
  */
 
-import { test } from '@japa/runner'
 import 'reflect-metadata'
+import { test } from '@japa/runner'
 import { Ioc } from '@adonisjs/fold'
 import { Kernel } from '@adonisjs/ace'
 import { testingRenderer } from '@poppinss/cliui'
@@ -52,6 +52,7 @@ test.group('Command | List Routes Json', (group) => {
         {
           root: [
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               name: '',
               pattern: '/about',
@@ -59,6 +60,7 @@ test.group('Command | List Routes Json', (group) => {
               middleware: [],
             },
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               name: '',
               pattern: '/contact',
@@ -92,6 +94,7 @@ test.group('Command | List Routes Json', (group) => {
         {
           root: [
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               name: '',
               pattern: '/about',
@@ -99,6 +102,7 @@ test.group('Command | List Routes Json', (group) => {
               middleware: [],
             },
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               name: '',
               pattern: '/contact',
@@ -135,6 +139,7 @@ test.group('Command | List Routes Json', (group) => {
         {
           root: [
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               pattern: '/about',
               name: '',
@@ -142,6 +147,7 @@ test.group('Command | List Routes Json', (group) => {
               middleware: [],
             },
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               pattern: '/contact',
               name: '',
@@ -178,6 +184,7 @@ test.group('Command | List Routes Json', (group) => {
         {
           root: [
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               pattern: '/about',
               name: '',
@@ -185,6 +192,7 @@ test.group('Command | List Routes Json', (group) => {
               middleware: [],
             },
             {
+              domain: 'root',
               methods: ['HEAD', 'GET'],
               pattern: '/contact',
               name: '',
@@ -218,6 +226,7 @@ test.group('Command | List Routes Json', (group) => {
         {
           'blogger.com': [
             {
+              domain: 'blogger.com',
               methods: ['HEAD', 'GET'],
               pattern: '/about',
               handler: 'Closure',
@@ -255,6 +264,7 @@ test.group('Command | List Routes Json', (group) => {
         {
           'blogger.com': [
             {
+              domain: 'blogger.com',
               methods: ['HEAD', 'GET'],
               pattern: '/v1/about',
               handler: 'Closure',

--- a/test/commands/list-routes-pretty.spec.ts
+++ b/test/commands/list-routes-pretty.spec.ts
@@ -42,7 +42,7 @@ test.group('Command | List Routes Pretty', (group) => {
     listRoutes = new ListRoutes(app, new Kernel(app))
     listRoutes.logger.useRenderer(testingRenderer)
     // @ts-ignore
-    listRoutes.getTerminalWidth = () => 50
+    listRoutes.maxWidth = 50
   })
 
   group.each.teardown(() => {


### PR DESCRIPTION
The PR contains following changes/improvements.

- Adding license docblock to all the files. Since, AdonisJS is not only maintained by me anymore, I have removed my name and email from the license block.
- Rename all instances of `serializedRouter` with `serializedRoutes`.
- Instead of passing too many arguments to the renders. I am passing the command instance to them.
- Replaced method bind calls like `this.colors.red.bind(this.colors)` with just the color name. Otherwise, we are creating 6-7 new methods.
- Move `getTerminalWidth` method to the PrettyListRenderer class. I believe, the renderer should be concerned with finding the columns width and not the ListRoute command.
- Introduce a new flag `maxWidth` to control the rendering width for the pretty list.

This PR does change the JSON output by adding the domain property to it. I did this to avoid re-mapping the routes within the `PrettyListRenderer` class and I think adding one new property to the JSON output will not hurt anyone.