### PR TITLE
fix: add stayAlive to ListRoutes command

### DIFF
--- a/commands/ListRoutes/index.ts
+++ b/commands/ListRoutes/index.ts
@@ -176,7 +176,7 @@ export default class ListRoutes extends BaseCommand {
     } else {
       new RoutesPrettyRenderer(this).render()
     }
-    
+
     await this.application.shutdown()
   }
 }

--- a/commands/ListRoutes/index.ts
+++ b/commands/ListRoutes/index.ts
@@ -61,6 +61,7 @@ export default class ListRoutes extends BaseCommand {
    */
   public static settings = {
     loadApp: true,
+    stayAlive: true,
   }
 
   /**
@@ -175,5 +176,7 @@ export default class ListRoutes extends BaseCommand {
     } else {
       new RoutesPrettyRenderer(this).render()
     }
+    
+    await this.application.shutdown()
   }
 }


### PR DESCRIPTION
As discussed here: https://github.com/Julien-R44/adonis-vscode-extension/issues/4

When many routes are defined, ListRoute does not wait until the queue of things to be printed is empty before killing the process, so we have to add stayAlive