### PR TITLE
Assign Fake assets driver when needed

### DIFF
--- a/src/AssetsManager/index.ts
+++ b/src/AssetsManager/index.ts
@@ -20,7 +20,6 @@ import {
 import { FakeDriver } from './Drivers/Fake'
 import { EncoreDriver } from './Drivers/Encore'
 import { ViteDriver } from './Drivers/Vite'
-import Env from '@ioc:Adonis/Core/Env'
 
 /**
  * Assets manager exposes the API to make link and HTML fragments
@@ -100,7 +99,7 @@ export class AssetsManager implements AssetsManagerContract {
      * Checks for using 'fake' driver
      */
     // TODO: Must be removed in v6
-    if (Env.get('ASSETS_DRIVER') === 'fake') {
+    if (this.application.env.get('ASSETS_DRIVER') === 'fake') {
       driver = 'fake'
 
       this.application.logger.warn(
@@ -108,7 +107,7 @@ export class AssetsManager implements AssetsManagerContract {
       )
     }
 
-    if (Env.get('NO_ASSETS_DRIVER') === 'true') {
+    if (this.application.env.get('NO_ASSETS_DRIVER') === 'true') {
       driver = 'fake'
     }
 

--- a/src/AssetsManager/index.ts
+++ b/src/AssetsManager/index.ts
@@ -20,6 +20,7 @@ import {
 import { FakeDriver } from './Drivers/Fake'
 import { EncoreDriver } from './Drivers/Encore'
 import { ViteDriver } from './Drivers/Vite'
+import Env from '@ioc:Adonis/Core/Env'
 
 /**
  * Assets manager exposes the API to make link and HTML fragments
@@ -93,7 +94,23 @@ export class AssetsManager implements AssetsManagerContract {
     }
 
     this.booted = true
-    const driver = this.config.driver || 'encore'
+    let driver = this.config.driver || 'encore'
+
+    /**
+     * Checks for using 'fake' driver
+     */
+    // TODO: Must be removed in v6
+    if (Env.get('ASSETS_DRIVER') === 'fake') {
+      driver = 'fake'
+
+      this.application.logger.warn(
+        'The ASSETS_DRIVER environment variable is deprecated. Use NO_ASSETS_DRIVER instead.'
+      )
+    }
+
+    if (Env.get('NO_ASSETS_DRIVER') === 'true') {
+      driver = 'fake'
+    }
 
     /**
      * Ensure driver name is recognized


### PR DESCRIPTION
Related to the discussion we had about the fake assets driver. 

We keep for the moment ASSETS_DRIVER='fake' to not create any breaking changes

And we introduce the variable NO_ASSETS_DRIVER=true or false

--- 

Was wondering how you proceed to keep track of code you added to keep retro compatibility, but that you need to remove for the next major release ? Here I just added a little TODO 

Tell me if you have a solution you are used to 