### PR TITLE
fix: default hasher mismatch fix

### DIFF
--- a/templates/config/hash.txt
+++ b/templates/config/hash.txt
@@ -23,7 +23,7 @@ export default hashConfig({
   | Default hasher
   |--------------------------------------------------------------------------
   |
-  | By default we make use of the argon hasher to hash values. However, feel
+  | By default we make use of the scrypt hasher to hash values. However, feel
   | free to change the default value
   |
   */


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Changes the comment for default hasher.
Here it is saying inside the comment that ```argon``` is the default hasher. But the default prop is set to ```scrypt```

<img width="553" alt="Screenshot 2022-12-05 214059" src="https://user-images.githubusercontent.com/13854024/206244082-6ba39a89-df81-4e52-9d2b-42465a5d80a1.png">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/core/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments
