### PR TITLE
docs(contributing): fix content table link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 AdonisJS is a community driven project. You are free to contribute in any of the following ways.
 
-- [Coding style](coding-style)
-- [Fix bugs by creating PR's](fix-bugs-by-creating-prs)
-- [Share an RFC for new features or big changes](share-an-rfc-for-new-features-or-big-changes)
-- [Report security issues](report-security-issues)
-- [Be a part of the community](be-a-part-of-community)
+- [Coding style](#coding-style)
+- [Fix bugs by creating PR's](#fix-bugs-by-creating-prs)
+- [Share an RFC for new features or big changes](#share-an-rfc-for-new-features-or-big-changes)
+- [Report security issues](#report-security-issues)
+- [Be a part of the community](#be-a-part-of-community)
 
 ## Coding style
 


### PR DESCRIPTION
## Proposed changes

Just adding a "#" in front of the contributing.md content table links. Currently it's causing a 404 on Github.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/core/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)


