### PR TITLE
feat: add `makeUsingStub` to BaseCommand

### DIFF
--- a/commands/make/_base.ts
+++ b/commands/make/_base.ts
@@ -7,7 +7,6 @@
  * file that was distributed with this source code.
  */
 
-import { slash } from '@poppinss/utils'
 import { stubsRoot } from '../../stubs/index.js'
 import { BaseCommand } from '../../modules/ace/main.js'
 import type { CommandOptions } from '../../types/ace.js'
@@ -27,29 +26,6 @@ export default abstract class extends BaseCommand {
    * Generates the resource from stub
    */
   protected async generate(stubPath: string, stubState: Record<string, any>) {
-    const stub = await this.app.stubs.build(stubPath, { source: stubsRoot })
-    const output = await stub.generate(
-      Object.assign(
-        {
-          flags: this.parsed.flags,
-        },
-        stubState
-      )
-    )
-
-    const entityFileName = slash(this.app.relativePath(output.destination))
-    if (output.status === 'skipped') {
-      this.logger.action(`create ${entityFileName}`).skipped(output.skipReason)
-      return {
-        ...output,
-        relativeFileName: entityFileName,
-      }
-    }
-
-    this.logger.action(`create ${entityFileName}`).succeeded()
-    return {
-      ...output,
-      relativeFileName: entityFileName,
-    }
+    return this.makeUsingStub(stubPath, stubState, stubsRoot)
   }
 }


### PR DESCRIPTION
## Proposed changes

Add a method `makeUsingStub` to Ace BaseCommand.

```ts
this.makeUsingStub(stubPath, stubState, stubsRoot)
 ```

## Further comments

Not sure about this PR. It doesn't seem very clean to me because we have a particular OOP architecture here and so I was forced to duplicate the code in `ListCommand`, and also to leave the `stubsGenerator` property in public. (that's also why I preferred to using composition here by extracting the StubGenerator class)

I almost went further and refactored it maybe with Mixins (to remove the fact that ListCommand implements BaseCommand) because it seems to be problematic 
But I prefered to keep it simple and just duplicate for the moment because it's a very small change

Let me know what you think!