### PR TITLE
feat: add `Configure.installPackages` method

### DIFF
--- a/commands/configure.ts
+++ b/commands/configure.ts
@@ -123,7 +123,7 @@ export default class Configure extends BaseCommand {
    * ```
    */
   async installPackages(packages: { name: string; isDevDependency: boolean }[]) {
-    const appPath = fileURLToPath(this.app.appRoot)
+    const appPath = this.app.makePath()
 
     const devDeps = packages.filter((pkg) => pkg.isDevDependency).map(({ name }) => name)
     const deps = packages.filter((pkg) => !pkg.isDevDependency).map(({ name }) => name)
@@ -142,8 +142,9 @@ export default class Configure extends BaseCommand {
       this.logger.log(devDeps.map((dep) => `      ${this.colors.dim('dev')} ${dep}`).join('\n'))
       this.logger.log(deps.map((dep) => `      ${this.colors.dim('prod')} ${dep}`).join('\n'))
     } catch (error) {
+      spinner.update('unable to install dependencies')
       spinner.stop()
-      this.logger.error(`unable to install dependencies :\n   ${this.colors.red(error.message)}`)
+      this.logger.fatal(error)
     }
   }
 

--- a/commands/configure.ts
+++ b/commands/configure.ts
@@ -11,6 +11,8 @@ import { slash } from '@poppinss/utils'
 import { EnvEditor } from '../modules/env.js'
 import type { ApplicationService } from '../src/types.js'
 import { args, BaseCommand } from '../modules/ace/main.js'
+import { installPackage, detectPackageManager } from '@antfu/install-pkg'
+import { fileURLToPath } from 'node:url'
 
 /**
  * The configure command is used to configure packages after installation
@@ -109,6 +111,40 @@ export default class Configure extends BaseCommand {
     await callback(this.app.rcFileEditor)
     await this.app.rcFileEditor.save()
     this.logger.action('update .adonisrc.json file').succeeded()
+  }
+
+  /**
+   * Install packages using the correct package manager
+   * You can specify version of each package by setting it in the
+   * name like :
+   *
+   * ```
+   * installPackages(['@adonisjs/lucid@next', '@adonisjs/auth@3.0.0'])
+   * ```
+   */
+  async installPackages(packages: { name: string; isDevDependency: boolean }[]) {
+    const appPath = fileURLToPath(this.app.appRoot)
+
+    const devDeps = packages.filter((pkg) => pkg.isDevDependency).map(({ name }) => name)
+    const deps = packages.filter((pkg) => !pkg.isDevDependency).map(({ name }) => name)
+
+    const packageManager = await detectPackageManager(appPath)
+    let spinner = this.logger
+      .await(`installing dependencies using ${packageManager || 'npm'}`)
+      .start()
+
+    try {
+      await installPackage(deps, { cwd: appPath, silent: true })
+      await installPackage(devDeps, { dev: true, cwd: appPath, silent: true })
+
+      spinner.stop()
+      this.logger.success('dependencies installed')
+      this.logger.log(devDeps.map((dep) => `      ${this.colors.dim('dev')} ${dep}`).join('\n'))
+      this.logger.log(deps.map((dep) => `      ${this.colors.dim('prod')} ${dep}`).join('\n'))
+    } catch (error) {
+      spinner.stop()
+      this.logger.error(`unable to install dependencies :\n   ${this.colors.red(error.message)}`)
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@adonisjs/hash": "^8.3.1-3",
     "@adonisjs/http-server": "^6.8.2-7",
     "@adonisjs/logger": "^5.4.2-3",
+    "@antfu/install-pkg": "^0.1.1",
     "@paralleldrive/cuid2": "^2.2.0",
     "@poppinss/macroable": "^1.0.0-7",
     "@poppinss/utils": "^6.5.0-3",

--- a/tests/commands/configure.spec.ts
+++ b/tests/commands/configure.spec.ts
@@ -532,9 +532,14 @@ test.group('Configure command | run', (group) => {
 
     const logs = ace.ui.logger.getLogs()
     assert.deepInclude(logs, {
-      message:
-        '[ red(error) ] unable to install dependencies :\n   red(Command failed with exit code 1: npm install -D is-odd@15.0.0)',
-      stream: 'stderr',
+      message: '[ cyan(wait) ] unable to install dependencies ...',
+      stream: 'stdout',
     })
+
+    const lastLog = logs[logs.length - 1]
+    assert.deepInclude(
+      lastLog.message,
+      '[ red(error) ] Command failed with exit code 1: npm install -D is-odd@15.0.0'
+    )
   }).timeout(5000)
 })


### PR DESCRIPTION
Add a `configure.installPackages` method that use `antfu/install-pkg` under the hood https://github.com/antfu/install-pkg. Doesnt bring any heavy dependency


Output :
![image](https://github.com/adonisjs/core/assets/8337858/7ab84ab4-0456-4d97-8579-a8e75f89594d)
