### PR TITLE
change: add PATCH as a default method for CORS headers

### DIFF
--- a/templates/config/cors.txt
+++ b/templates/config/cors.txt
@@ -56,7 +56,7 @@ const corsConfig: CorsConfig = {
   |
   | Following is the list of default methods. Feel free to add more.
   */
-  methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'],
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH'],
 
   /*
   |--------------------------------------------------------------------------

--- a/templates/config/cors.txt
+++ b/templates/config/cors.txt
@@ -56,7 +56,7 @@ const corsConfig: CorsConfig = {
   |
   | Following is the list of default methods. Feel free to add more.
   */
-  methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'],
 
   /*
   |--------------------------------------------------------------------------


### PR DESCRIPTION
## Proposed changes
Hello 👋 

Is there a specific reason that PATCH was not included as a default method for the CORS configuration? It took me a little bit of stumbling around to figure out why PATCH requests weren't working for me. It was surprising to me that this was not a default. 

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_
(not positive here, since this is a template that would likely only affect new projects, I'm considering it a new feature).
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/core/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The docs would need to be updated too if this change were to be accepted.
