### PR TITLE
fix(commands): swapped description -a & -r for make:controller

### DIFF
--- a/commands/make/controller.ts
+++ b/commands/make/controller.ts
@@ -31,13 +31,13 @@ export default class MakeController extends BaseCommand {
   declare singular: boolean
 
   @flags.boolean({
-    description: 'Generate controller with methods to perform CRUD actions on a resource',
+    description: 'Generate resourceful controller with the "edit" and the "create" methods',
     alias: 'r',
   })
   declare resource: boolean
 
   @flags.boolean({
-    description: 'Generate resourceful controller with the "edit" and the "create" methods',
+    description: 'Generate controller with methods to perform CRUD actions on a resource',
     alias: 'a',
   })
   declare api: boolean


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#4419

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves #4419.
The `--api` & `--resource` argument descriptions of `make:controller` were swapped.
I just swapped them so that the descriptions make sense again.
`--resource` is the one that generates `edit` & `create` methods.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
