### PR TITLE
feat(helpers): re-export Opaque type

### DIFF
--- a/src/helpers/main.ts
+++ b/src/helpers/main.ts
@@ -22,4 +22,5 @@ export {
   fsImportAll,
   MessageBuilder,
 } from '@poppinss/utils'
+export type { Opaque } from '@poppinss/utils/types'
 export { parseBindingReference } from './parse_binding_reference.js'


### PR DESCRIPTION
Hey there! 👋🏻 

This PR re-export the `Opaque` helper from `@poppinss/utils`.