### PR TITLE
feat: do not run assets bundler when explicitely disabled in rc file

### DIFF
--- a/src/internal_helpers.ts
+++ b/src/internal_helpers.ts
@@ -49,6 +49,10 @@ function generateJsFilenames(filename: string) {
 export async function detectAssetsBundler(
   app: ApplicationService
 ): Promise<RcFile['assetsBundler']> {
+  if (app.rcFile.assetsBundler === false) {
+    return false
+  }
+
   if (app.rcFile.assetsBundler) {
     return app.rcFile.assetsBundler
   }


### PR DESCRIPTION
Users can now totally disable the assets bundler logic integrated in the assembler, and this from the RCFile : 

```ts
// adonisrc.ts
export default defineConfig({
  // Disable assembler built-in assets bundler
  assetsBundler: false, 
  
  assembler: {
    onDevServerStarting: [
      // Let @adonisjs/vite manage the assets bundling itself
      () => import('@adonisjs/vite/build_hook')
    ]
  }
})
```

This is useful in our case, because with the next Vite integration, adonisjs/vite itself will launch the vite dev server

One thing to note : It's weird to set `assetsBundler` to false when you want to use Vite. It's not logical at all for users who don't know about internals of Adonis. But for the moment, we don't have much choice. Later, if our new Vite integration is successful, we should be able to remove all asset bundling logic from the Assembler. And also, we should be able to remove this `assetsBundler` configuration property from the RC File.