### PR TITLE
fix(docs): update broken link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
       Guides
     </a>
     <span> | </span>
-    <a href=".github/CONTRIBUTING.md">
+    <a href=".github/blob/main/docs/CONTRIBUTING.md">
       Contributing
     </a>
   </h3>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
       Guides
     </a>
     <span> | </span>
-    <a href=".github/blob/main/docs/CONTRIBUTING.md">
+    <a href="https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md">
       Contributing
     </a>
   </h3>


### PR DESCRIPTION
Found a broken link in the readme.md for the core project, that it was incorrectly pointing to a (presumably older) wrong location for the contribution docs.
I have updated the link.

### 🔗 Linked issue

No linked issues that I'm aware of, it's a small documentation update.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Updates broken link in documentation

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
