### PR TITLE
feat: add `--hmr` flag for the `serve` command

### DIFF
--- a/commands/serve.ts
+++ b/commands/serve.ts
@@ -28,6 +28,11 @@ export default class Serve extends BaseCommand {
     '{{ binaryName }} serve --watch',
     '```',
     '',
+    'You can also start the server with HMR support using the following command.',
+    '```',
+    '{{ binaryName }} serve --hmr',
+    '```',
+    '',
     'The assets bundler dev server runs automatically after detecting vite config or webpack config files',
     'You may pass vite CLI args using the --assets-args command line flag.',
     '```',
@@ -40,6 +45,9 @@ export default class Serve extends BaseCommand {
   }
 
   declare devServer: DevServer
+
+  @flags.boolean({ description: 'Start the server with HMR support' })
+  declare hmr?: boolean
 
   @flags.boolean({
     description: 'Watch filesystem and restart the HTTP server on file change',
@@ -112,7 +120,14 @@ export default class Serve extends BaseCommand {
       return
     }
 
+    if (this.watch && this.hmr) {
+      this.logger.error('Cannot use --watch and --hmr flags together. Choose one of them')
+      this.exitCode = 1
+      return
+    }
+
     this.devServer = new assembler.DevServer(this.app.appRoot, {
+      hmr: this.hmr === true ? true : false,
       clearScreen: this.clear === false ? false : true,
       nodeArgs: this.parsed.nodeArgs,
       scriptArgs: [],

--- a/commands/serve.ts
+++ b/commands/serve.ts
@@ -30,7 +30,7 @@ export default class Serve extends BaseCommand {
     '',
     'You can also start the server with HMR support using the following command.',
     '```',
-    '{{ binaryName }} serve --hmr',
+    '{{ binaryName }} serve --unstable-hmr',
     '```',
     '',
     'The assets bundler dev server runs automatically after detecting vite config or webpack config files',
@@ -47,7 +47,7 @@ export default class Serve extends BaseCommand {
   declare devServer: DevServer
 
   @flags.boolean({ description: 'Start the server with HMR support' })
-  declare hmr?: boolean
+  declare unstableHmr?: boolean
 
   @flags.boolean({
     description: 'Watch filesystem and restart the HTTP server on file change',
@@ -120,14 +120,14 @@ export default class Serve extends BaseCommand {
       return
     }
 
-    if (this.watch && this.hmr) {
-      this.logger.error('Cannot use --watch and --hmr flags together. Choose one of them')
+    if (this.watch && this.unstableHmr) {
+      this.logger.error('Cannot use --watch and --unstable-hmr flags together. Choose one of them')
       this.exitCode = 1
       return
     }
 
     this.devServer = new assembler.DevServer(this.app.appRoot, {
-      hmr: this.hmr === true ? true : false,
+      hmr: this.unstableHmr === true ? true : false,
       clearScreen: this.clear === false ? false : true,
       nodeArgs: this.parsed.nodeArgs,
       scriptArgs: [],

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "index:commands": "node --loader=ts-node/esm toolkit/main.js index build/commands"
   },
   "devDependencies": {
-    "@adonisjs/assembler": "^7.4.0",
+    "@adonisjs/assembler": "^7.5.0",
     "@adonisjs/eslint-config": "^1.3.0",
     "@adonisjs/prettier-config": "^1.3.0",
     "@adonisjs/tsconfig": "^1.3.0",
@@ -143,7 +143,7 @@
     "youch-terminal": "^2.2.3"
   },
   "peerDependencies": {
-    "@adonisjs/assembler": "^7.1.0",
+    "@adonisjs/assembler": "^7.5.0",
     "@vinejs/vine": "^2.0.0",
     "argon2": "^0.31.2 || ^0.40.0",
     "bcrypt": "^5.1.1",

--- a/tests/commands/serve.spec.ts
+++ b/tests/commands/serve.spec.ts
@@ -337,4 +337,22 @@ test.group('Serve command', () => {
     await command.exec()
     await sleep(1200)
   })
+
+  test('error if --hmr and --watch are used together', async ({ assert, fs, cleanup }) => {
+    await fs.create('node_modules/ts-node/esm.js', '')
+
+    const ace = await new AceFactory().make(fs.baseUrl, {
+      importer: (filePath) => import(filePath),
+    })
+
+    ace.ui.switchMode('raw')
+
+    const command = await ace.create(Serve, ['--hmr', '--watch', '--no-clear'])
+    await command.exec()
+
+    assert.equal(command.exitCode, 1)
+    assert.lengthOf(ace.ui.logger.getLogs(), 1)
+    assert.equal(ace.ui.logger.getLogs()[0].stream, 'stderr')
+    assert.match(ace.ui.logger.getLogs()[0].message, /Cannot use --watch and --hmr flags together/)
+  })
 })

--- a/tests/commands/serve.spec.ts
+++ b/tests/commands/serve.spec.ts
@@ -338,7 +338,7 @@ test.group('Serve command', () => {
     await sleep(1200)
   })
 
-  test('error if --unstable-hmr and --watch are used together', async ({ assert, fs, cleanup }) => {
+  test('error if --unstable-hmr and --watch are used together', async ({ assert, fs }) => {
     await fs.create('node_modules/ts-node/esm.js', '')
 
     const ace = await new AceFactory().make(fs.baseUrl, {

--- a/tests/commands/serve.spec.ts
+++ b/tests/commands/serve.spec.ts
@@ -338,7 +338,7 @@ test.group('Serve command', () => {
     await sleep(1200)
   })
 
-  test('error if --hmr and --watch are used together', async ({ assert, fs, cleanup }) => {
+  test('error if --unstable-hmr and --watch are used together', async ({ assert, fs, cleanup }) => {
     await fs.create('node_modules/ts-node/esm.js', '')
 
     const ace = await new AceFactory().make(fs.baseUrl, {
@@ -347,12 +347,15 @@ test.group('Serve command', () => {
 
     ace.ui.switchMode('raw')
 
-    const command = await ace.create(Serve, ['--hmr', '--watch', '--no-clear'])
+    const command = await ace.create(Serve, ['--unstable-hmr', '--watch', '--no-clear'])
     await command.exec()
 
     assert.equal(command.exitCode, 1)
     assert.lengthOf(ace.ui.logger.getLogs(), 1)
     assert.equal(ace.ui.logger.getLogs()[0].stream, 'stderr')
-    assert.match(ace.ui.logger.getLogs()[0].message, /Cannot use --watch and --hmr flags together/)
+    assert.match(
+      ace.ui.logger.getLogs()[0].message,
+      /Cannot use --watch and --unstable-hmr flags together/
+    )
   })
 })


### PR DESCRIPTION
Depends on https://github.com/adonisjs/assembler/pull/77. Must be merged and released first

---

Add the flag `--hmr` that will be passed to Assembler DevServer class

`--hmr` and `--watch` cannot be used together, since `--hmr` also watch files. so we display an error if we use them together