### PR TITLE
fix: honor configured controller directory in barrel generation

### DIFF
--- a/commands/build.ts
+++ b/commands/build.ts
@@ -103,10 +103,12 @@ export default class Build extends BaseCommand {
       return
     }
 
-    const bundler = new assembler.Bundler(this.app.appRoot, ts, {
+    const assemblerOptions = {
       metaFiles: this.app.rcFile.metaFiles,
       hooks: this.app.rcFile.hooks,
-    })
+      directories: this.app.rcFile.directories,
+    }
+    const bundler = new assembler.Bundler(this.app.appRoot, ts, assemblerOptions)
 
     /**
      * Share command logger with assembler, so that CLI flags like --no-ansi has

--- a/commands/serve.ts
+++ b/commands/serve.ts
@@ -135,14 +135,16 @@ export default class Serve extends BaseCommand {
       return
     }
 
-    this.devServer = new assembler.DevServer(this.app.appRoot, {
+    const assemblerOptions = {
       hmr: this.hmr === true ? true : false,
       clearScreen: this.clear === false ? false : true,
       nodeArgs: this.parsed.nodeArgs,
       scriptArgs: [],
       metaFiles: this.app.rcFile.metaFiles,
       hooks: this.app.rcFile.hooks,
-    })
+      directories: this.app.rcFile.directories,
+    }
+    this.devServer = new assembler.DevServer(this.app.appRoot, assemblerOptions)
 
     /**
      * Share command logger with assembler, so that CLI flags like --no-ansi has

--- a/commands/test.ts
+++ b/commands/test.ts
@@ -197,7 +197,7 @@ export default class Test extends BaseCommand {
       return
     }
 
-    this.testsRunner = new assembler.TestRunner(this.app.appRoot, {
+    const assemblerOptions = {
       clearScreen: this.clear === false ? false : true,
       nodeArgs: this.parsed.nodeArgs,
       scriptArgs: this.#getPassthroughFlags(),
@@ -223,7 +223,9 @@ export default class Test extends BaseCommand {
       },
       hooks: this.app.rcFile.hooks,
       metaFiles: this.app.rcFile.metaFiles,
-    })
+      directories: this.app.rcFile.directories,
+    }
+    this.testsRunner = new assembler.TestRunner(this.app.appRoot, assemblerOptions)
 
     /**
      * Share command logger with assembler, so that CLI flags like --no-ansi has

--- a/src/assembler_hooks/index_entities.ts
+++ b/src/assembler_hooks/index_entities.ts
@@ -8,9 +8,14 @@
  */
 
 import { type CommonHooks } from '@adonisjs/assembler/types'
+import { type DirectoriesNode } from '@adonisjs/application/types'
 import stringHelpers from '../helpers/string.ts'
 import { type IndexEntitiesConfig } from '../types.ts'
 import { outputTransformerDataObjects } from '../utils.ts'
+
+type AssemblerOptionsWithDirectories = {
+  directories?: Partial<DirectoriesNode>
+}
 
 /**
  * Configures the IndexGenerator to create barrel files for "controllers", "events",
@@ -74,7 +79,6 @@ export function indexEntities(entities: IndexEntitiesConfig = {}) {
   const controllers = Object.assign(
     {
       enabled: true,
-      source: 'app/controllers',
       importAlias: '#controllers',
       skipSegments: ['controllers'],
       output: '.adonisjs/server/controllers.ts',
@@ -112,7 +116,11 @@ export function indexEntities(entities: IndexEntitiesConfig = {}) {
   }
 
   return {
-    run(_, __, indexGenerator) {
+    run(parent, _, indexGenerator) {
+      const directories = (
+        parent.options as (typeof parent.options & AssemblerOptionsWithDirectories) | undefined
+      )?.directories
+
       if (events.enabled) {
         indexGenerator.add('events', {
           source: events.source,
@@ -142,7 +150,7 @@ export function indexEntities(entities: IndexEntitiesConfig = {}) {
 
       if (controllers.enabled) {
         indexGenerator.add('controllers', {
-          source: controllers.source,
+          source: controllers.source ?? directories?.httpControllers ?? 'app/controllers',
           glob: controllers.glob,
           as: 'barrelFile',
           exportName: 'controllers',

--- a/tests/commands/build.spec.ts
+++ b/tests/commands/build.spec.ts
@@ -265,7 +265,7 @@ test.group('Build command', (group) => {
   })
 
   test('correctly pass hooks to the bundler', async ({ assert, fs }) => {
-    assert.plan(2)
+    assert.plan(3)
 
     await fs.create(
       'tsconfig.json',
@@ -291,7 +291,18 @@ test.group('Build command', (group) => {
       },
     })
 
+    ace.app.rcFile.directories.httpControllers = 'src/infrastructure/api/http/controllers'
     ace.app.rcFile.hooks = {
+      init: [
+        {
+          run(parent) {
+            assert.equal(
+              (parent.options as any).directories.httpControllers,
+              'src/infrastructure/api/http/controllers'
+            )
+          },
+        },
+      ],
       buildFinished: [
         async () => ({
           default: async () => {

--- a/tests/commands/serve.spec.ts
+++ b/tests/commands/serve.spec.ts
@@ -81,7 +81,7 @@ test.group('Serve command', () => {
   })
 
   test('correctly pass hooks to the DevServer', async ({ assert, fs, cleanup }) => {
-    assert.plan(1)
+    assert.plan(2)
     await fs.create('bin/server.ts', `process.send({ isAdonisJS: true, environment: 'web' });`)
 
     await setupTypeScriptProject()
@@ -90,7 +90,18 @@ test.group('Serve command', () => {
       importer: (filePath) => import(filePath),
     })
 
+    ace.app.rcFile.directories.httpControllers = 'src/infrastructure/api/http/controllers'
     ace.app.rcFile.hooks = {
+      init: [
+        {
+          run(parent) {
+            assert.equal(
+              (parent.options as any).directories.httpControllers,
+              'src/infrastructure/api/http/controllers'
+            )
+          },
+        },
+      ],
       devServerStarted: [
         async () => ({
           default: async () => {

--- a/tests/commands/test.spec.ts
+++ b/tests/commands/test.spec.ts
@@ -275,6 +275,8 @@ test.group('Test command', () => {
   })
 
   test('pass all japa flags to the script', async ({ assert, fs, cleanup }) => {
+    assert.plan(2)
+
     await fs.create(
       'package.json',
       JSON.stringify({
@@ -299,6 +301,19 @@ test.group('Test command', () => {
     })
 
     ace.ui.switchMode('raw')
+    ace.app.rcFile.directories.httpControllers = 'src/infrastructure/api/http/controllers'
+    ace.app.rcFile.hooks = {
+      init: [
+        {
+          run(parent) {
+            assert.equal(
+              (parent.options as any).directories.httpControllers,
+              'src/infrastructure/api/http/controllers'
+            )
+          },
+        },
+      ],
+    }
     ace.app.rcFile.tests.suites = [
       {
         name: 'unit',

--- a/tests/index_generator.spec.ts
+++ b/tests/index_generator.spec.ts
@@ -54,6 +54,46 @@ test.group('Index generator', () => {
     )
   })
 
+  test('generate controllers index from the configured directory', async ({ assert, fs }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('src/infrastructure/api/http/controllers/users_controller.ts', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    const indexer = indexEntities({
+      controllers: {
+        enabled: true,
+      },
+      events: {
+        enabled: false,
+      },
+      listeners: {
+        enabled: false,
+      },
+      transformers: {
+        enabled: false,
+      },
+    })
+
+    indexer.run(
+      {
+        options: {
+          directories: {
+            httpControllers: 'src/infrastructure/api/http/controllers',
+          },
+        },
+      } as any,
+      {} as any,
+      generator
+    )
+    await generator.generate()
+
+    await assert.fileContains('.adonisjs/server/controllers.ts', [
+      `Users: () => import('#controllers/users_controller')`,
+    ])
+  })
+
   test('generate events index', async ({ assert, fs }) => {
     const cliUi = Kernel.create().ui
     cliUi.switchMode('raw')


### PR DESCRIPTION
### Summary

- pass the application's normalized `rcFile.directories` to the assembler from the `serve`, `test`, and `build` commands
- use `directories.httpControllers` for controller barrel generation when `controllers.source` is not explicitly configured
- preserve the existing explicit source override and `app/controllers` fallback

Fixes #5133.

### Verification

- pre-fix regression tests: four focused failures covering the hook plus `serve`, `build`, and `test` passthrough paths
- focused regression tests: 4 passing
- related suites: 37 passing
- complete `npm run quick:test`: 324 passing
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

Verified with Node 24.16.0 and pnpm 11.21.0.

The implementation and review used AI assistance. The final diff, RED/GREEN behavior, full test suite, lint, and type checks were independently verified before submission.
