### PR TITLE
feat: connect number helpers from @poppinss/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@poppinss/colors": "^4.1.6",
     "@poppinss/dumper": "^0.7.0",
     "@poppinss/macroable": "^1.1.2",
-    "@poppinss/utils": "^7.0.1",
+    "@poppinss/utils": "^7.1.0",
     "@sindresorhus/is": "^8.1.0",
     "@types/he": "^1.2.3",
     "error-stack-parser-es": "^2.0.1",

--- a/providers/edge_provider.ts
+++ b/providers/edge_provider.ts
@@ -10,6 +10,7 @@
 import edge, { type Edge } from 'edge.js'
 import { type URLOptions } from '../types/http.ts'
 import type { ApplicationService } from '../src/types.ts'
+import numberHelpers from '../src/helpers/number.ts'
 import { pluginEdgeDumper } from '../modules/dumper/plugins/edge.ts'
 import { BriskRoute, HttpContext, Qs, type Route, type Router } from '../modules/http/main.ts'
 import { type ClientRouteJSON } from '@adonisjs/http-server/client/url_builder'
@@ -145,6 +146,7 @@ export default class EdgeServiceProvider {
 
     edge.global('app', app)
     edge.global('config', edgeConfigResolver)
+    edge.global('number', numberHelpers)
     edge.global('routes', function () {
       return clientRoutes()
     })

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -1,0 +1,30 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import number from '@poppinss/utils/number'
+
+/**
+ * Collection of number helpers to clamp, parse, and convert numeric values.
+ * This object re-exports the base number utilities from @poppinss/utils.
+ *
+ * @example
+ * // Constrain and inspect values
+ * numberHelpers.clamp(15, 0, 10)  // 10
+ * numberHelpers.between(5, 0, 10) // true
+ *
+ * @example
+ * // Parse untrusted input
+ * numberHelpers.parse('42')        // 42
+ * numberHelpers.toFinite('abc', 0) // 0
+ */
+const numberHelpers: typeof number = {
+  ...number,
+}
+
+export default numberHelpers

--- a/tests/bindings/edge.spec.ts
+++ b/tests/bindings/edge.spec.ts
@@ -40,6 +40,7 @@ test.group('Bindings | Edge', () => {
     assert.isFalse(edge.globals.config.has('foobar'))
     assert.strictEqual(edge.globals.app, app)
     assert.instanceOf(edge.globals.qs, Qs)
+    assert.equal(edge.globals.number.clamp(15, 0, 10), 10)
 
     const router = await app.container.make('router')
     router.get('/users/:id', () => {})
@@ -79,6 +80,31 @@ test.group('Bindings | Edge', () => {
 
     await route?.route.execute(route.route, app.container.createResolver(), ctx, () => {})
     assert.equal(ctx.response.getBody(), 'Hello virk')
+  })
+
+  test('use number helpers inside templates', async ({ assert }) => {
+    const ignitor = new IgnitorFactory()
+      .merge({
+        rcFileContents: {
+          providers: [
+            () => import('../../providers/app_provider.js'),
+            () => import('../../providers/edge_provider.js'),
+          ],
+        },
+      })
+      .withCoreConfig()
+      .create(BASE_URL)
+
+    const app = ignitor.createApp('console')
+    await app.init()
+    await app.boot()
+
+    edge.registerTemplate('score', {
+      template: `{{ number.clamp(score, 0, 10) }} {{ number.between(score, 0, 10) }} {{ number.toFinite(raw, 0) }} {{ number.parse(valid) }}`,
+    })
+
+    const html = await edge.render('score', { score: 15, raw: 'abc', valid: '8' })
+    assert.equal(html, '10 false 0 8')
   })
 
   test('make form action using formAttributes helper', async ({ assert }) => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Re-exports number helpers from `@poppinss/utils` as `@adonisjs/core/helpers/number`.

Methods: `clamp`, `between`, `toFinite`, `parse`.

The helpers are also registered as the Edge global `number`.

Bumps `@poppinss/utils` to `^7.1.0` so the `/number` export is available.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.